### PR TITLE
Set the batch size down, and body size limit up

### DIFF
--- a/src/Datalust.ClefTool/Cli/Commands/PipeCommand.cs
+++ b/src/Datalust.ClefTool/Cli/Commands/PipeCommand.cs
@@ -69,6 +69,8 @@ namespace Datalust.ClefTool.Cli.Commands
                         _seqOutputFeature.SeqUrl,
                         apiKey: _seqOutputFeature.SeqApiKey,
                         compact: true,
+                        batchPostingLimit: 100,
+                        eventBodyLimitBytes: 1024 * 1024,
                         controlLevelSwitch: levelSwitch);
                 }
                 else if (_jsonFormatFeature.UseJsonFormat)


### PR DESCRIPTION
Avoid having batches rejected or events pre-emptively dropped at the client when writing to Seq