### PR TITLE
Add --invalid-data=ignore options to CLI

### DIFF
--- a/clef-tool.sln
+++ b/clef-tool.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26403.3
+VisualStudioVersion = 15.0.26403.7
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{61556DAE-6B5F-472B-AA8F-6E36E6B1376D}"
 EndProject
@@ -27,6 +27,11 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Datalust.ClefTool.Tests", "test\Datalust.ClefTool.Tests\Datalust.ClefTool.Tests.csproj", "{8603CDF1-1B8D-4762-B5CB-7BD5DA40C16A}"
 EndProject
 Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "Datalust.ClefTool.Setup", "setup\Datalust.ClefTool.Setup\Datalust.ClefTool.Setup.wixproj", "{F3A1944B-FF13-4250-A7F1-581CBB99A9BF}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "data", "data", "{0DA54CF5-F0A9-4A0B-B5F3-B3CB0902EAAE}"
+	ProjectSection(SolutionItems) = preProject
+		data\example.clef = data\example.clef
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Datalust.ClefTool/Cli/Commands/PipeCommand.cs
+++ b/src/Datalust.ClefTool/Cli/Commands/PipeCommand.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.IO;
 using Datalust.ClefTool.Cli.Features;
+using Datalust.ClefTool.Pipe;
 using Serilog;
 using Serilog.Core;
 using Serilog.Debugging;
@@ -22,6 +23,7 @@ namespace Datalust.ClefTool.Cli.Commands
         readonly FileOutputFeature _fileOutputFeature;
         readonly TemplateFormatFeature _templateFormatFeature;
         readonly SeqOutputFeature _seqOutputFeature;
+        readonly InvalidDataHandlingFeature _invalidDataHandlingFeature;
 
         // Include `{Properties}` once it's supported (Serilog 2.5)
         const string DefaultOutputTemplate = "{Timestamp:o} [{Level:u3}] {Message}{NewLine}{Exception}";
@@ -35,7 +37,7 @@ namespace Datalust.ClefTool.Cli.Commands
             _jsonFormatFeature = Enable<JsonFormatFeature>();
             _templateFormatFeature = Enable<TemplateFormatFeature>();
             _seqOutputFeature = Enable<SeqOutputFeature>();
-            
+            _invalidDataHandlingFeature = Enable<InvalidDataHandlingFeature>();
         }
 
         protected override int Run()
@@ -88,7 +90,9 @@ namespace Datalust.ClefTool.Cli.Commands
                     if (_fileOutputFeature.OutputFilename != null)
                     {
                         // This will differ slightly from the console output until `{Message:l}` becomes available
-                        configuration.AuditTo.File(new MessageTemplateTextFormatter(template, CultureInfo.InvariantCulture), _fileOutputFeature.OutputFilename);
+                        configuration.AuditTo.File(
+                            new MessageTemplateTextFormatter(template, CultureInfo.InvariantCulture),
+                            _fileOutputFeature.OutputFilename);
                     }
                     else
                     {
@@ -97,15 +101,13 @@ namespace Datalust.ClefTool.Cli.Commands
                 }
 
                 using (var logger = configuration.CreateLogger())
-                using (var inputFile = _fileInputFeature.InputFilename != null ?
-                    new StreamReader(File.Open(_fileInputFeature.InputFilename, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)) :
-                    null)
+                using (var inputFile = _fileInputFeature.InputFilename != null
+                    ? new StreamReader(File.Open(_fileInputFeature.InputFilename, FileMode.Open, FileAccess.Read,
+                        FileShare.ReadWrite))
+                    : null)
                 using (var reader = new LogEventReader(inputFile ?? Console.In))
                 {
-                    while (reader.TryRead(out var evt))
-                    {
-                        logger.Write(evt);
-                    }
+                    EventPipe.PipeEvents(reader, logger, _invalidDataHandlingFeature.InvalidDataHandling);
                 }
 
                 return failed ? 1 : 0;

--- a/src/Datalust.ClefTool/Cli/Features/InvalidDataHandlingFeature.cs
+++ b/src/Datalust.ClefTool/Cli/Features/InvalidDataHandlingFeature.cs
@@ -1,0 +1,31 @@
+﻿// Copyright 2016-2017 Datalust Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Datalust.ClefTool.Pipe;
+
+namespace Datalust.ClefTool.Cli.Features
+{
+    class InvalidDataHandlingFeature : CommandFeature
+    {
+        public InvalidDataHandling InvalidDataHandling { get; private set; }
+
+        public override void Enable(OptionSet options)
+        {
+            options.Add("invalid-data",
+                "Specify how invalid data is handled: fail (default), ignore, or report",
+                v => InvalidDataHandling = (InvalidDataHandling)Enum.Parse(typeof(InvalidDataHandling), v, ignoreCase: true));
+        }
+    }
+}

--- a/src/Datalust.ClefTool/Pipe/EventPipe.cs
+++ b/src/Datalust.ClefTool/Pipe/EventPipe.cs
@@ -1,0 +1,57 @@
+﻿// Copyright 2016-2017 Datalust Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.IO;
+using Newtonsoft.Json;
+using Serilog.Core;
+using Serilog.Formatting.Compact.Reader;
+
+namespace Datalust.ClefTool.Pipe
+{
+    static class EventPipe
+    {
+        public static void PipeEvents(LogEventReader source, Logger destination, InvalidDataHandling invalidDataHandling)
+        {
+            do
+            {
+                try
+                {
+                    while (source.TryRead(out var evt))
+                    {
+                        destination.Write(evt);
+                    }
+
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    if (ex is JsonReaderException || ex is InvalidDataException)
+                    {
+                        if (invalidDataHandling == InvalidDataHandling.Ignore)
+                            continue;
+
+                        if (invalidDataHandling == InvalidDataHandling.Report)
+                        {
+                            destination.Error(ex, "An event was not in CLEF format.");
+                            continue;
+                        }
+                    }
+
+                    throw;
+                }
+            } while (true);
+        }
+    }
+}

--- a/src/Datalust.ClefTool/Pipe/InvalidDataHandling.cs
+++ b/src/Datalust.ClefTool/Pipe/InvalidDataHandling.cs
@@ -1,0 +1,23 @@
+// Copyright 2016-2017 Datalust Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Datalust.ClefTool.Pipe
+{
+    enum InvalidDataHandling
+    {
+        Fail,
+        Ignore,
+        Report
+    }
+}

--- a/src/Datalust.ClefTool/Properties/AssemblyInfo.cs
+++ b/src/Datalust.ClefTool/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Datalust.ClefTool.Tests")]

--- a/test/Datalust.ClefTool.Tests/Datalust.ClefTool.Tests.csproj
+++ b/test/Datalust.ClefTool.Tests/Datalust.ClefTool.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
     <TargetFramework>netcoreapp1.1</TargetFramework>
@@ -8,6 +8,23 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Datalust.ClefTool\Datalust.ClefTool.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Serilog">
+      <HintPath>..\..\..\..\..\Users\nblumhardt\.nuget\packages\serilog\2.4.0\lib\netstandard1.3\Serilog.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Formatting.Compact.Reader">
+      <HintPath>..\..\..\..\..\Users\nblumhardt\.nuget\packages\serilog.formatting.compact.reader\1.0.0\lib\netstandard1.0\Serilog.Formatting.Compact.Reader.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/test/Datalust.ClefTool.Tests/Pipe/EventPipeTests.cs
+++ b/test/Datalust.ClefTool.Tests/Pipe/EventPipeTests.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.IO;
+using Datalust.ClefTool.Pipe;
+using Datalust.ClefTool.Tests.Support;
+using Newtonsoft.Json;
+using Serilog;
+using Serilog.Events;
+using Serilog.Formatting.Compact.Reader;
+using Xunit;
+
+namespace Datalust.ClefTool.Tests.Pipe
+{
+    public class EventPipeTests
+    {
+        static readonly string ClefThreeEvents =
+            "{\"@t\":\"2017-04-20T04:24:47.0251719Z\",\"@mt\":\"Loop {Counter}\",\"Counter\":0}" + Environment.NewLine +
+            "{\"@t\":\"2017-04-20T04:24:47.0371689Z\",\"@mt\":\"Loop {Counter}\",\"Counter\":1}" + Environment.NewLine +
+            "{\"@t\":\"2017-04-20T04:24:47.0371689Z\",\"@mt\":\"Loop {Counter}\",\"Counter\":2}" + Environment.NewLine;
+
+        static readonly string ClefTwoValidOneInvalid =
+            "{\"@t\":\"2017-04-20T04:24:47.0251719Z\",\"@mt\":\"Loop {Counter}\",\"Counter\":0}" + Environment.NewLine +
+            "Hello, world!" + Environment.NewLine +
+            "{\"@t\":\"2017-04-20T04:24:47.0371689Z\",\"@mt\":\"Loop {Counter}\",\"Counter\":2}" + Environment.NewLine;
+
+        [Fact]
+        public void EventsAreCopiedFromSourceToDestination()
+        {
+            var output = PipeEvents(ClefThreeEvents, InvalidDataHandling.Fail);
+            Assert.Equal(3, output.Length);
+        }
+
+        [Fact]
+        public void InFailModeInvalidJsonThrows()
+        {
+            Assert.Throws<JsonReaderException>(() => PipeEvents(ClefTwoValidOneInvalid, InvalidDataHandling.Fail));
+        }
+
+        [Fact]
+        public void InIgnoreModeInvalidJsonIsDropped()
+        {
+            var output = PipeEvents(ClefTwoValidOneInvalid, InvalidDataHandling.Ignore);
+            Assert.Equal(2, output.Length);
+        }
+
+        [Fact]
+        public void InReportModeInvalidJsonIsReported()
+        {
+            var output = PipeEvents(ClefTwoValidOneInvalid, InvalidDataHandling.Report);
+            Assert.Equal(3, output.Length);
+        }
+
+        static LogEvent[] PipeEvents(string input, InvalidDataHandling invalidDataHandling)
+        {
+            var output = new CollectingSink();
+            using (var source = new LogEventReader(new StringReader(input)))
+            using (var destination = new LoggerConfiguration()
+                .MinimumLevel.Is(LevelAlias.Minimum)
+                .WriteTo.Sink(output)
+                .CreateLogger())
+            {
+                EventPipe.PipeEvents(source, destination, invalidDataHandling);
+            }
+
+            return output.Events;
+        }
+    }
+}

--- a/test/Datalust.ClefTool.Tests/Support/CollectingSink.cs
+++ b/test/Datalust.ClefTool.Tests/Support/CollectingSink.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Datalust.ClefTool.Tests.Support
+{
+    public class CollectingSink : ILogEventSink
+    {
+        readonly object _sync = new object();
+        readonly List<LogEvent> _events = new List<LogEvent>();
+
+        public void Emit(LogEvent logEvent)
+        {
+            lock (_sync)
+                _events.Add(logEvent);
+        }
+
+        public LogEvent[] Events
+        {
+            get
+            {
+                lock (_sync)
+                    return _events.ToArray();
+            }
+        }
+    }
+}


### PR DESCRIPTION
New argument:

 * `--invalid-data=fail` - the default; error out when invalid JSON is encountered
 * `--invalid-data=ignore` - just drop any lines that are not JSON
 * `--invalid-data=report` - send an error down the line when invalid JSON is encountered


