### PR TITLE
Take upstream $type round-tripping fix

### DIFF
--- a/src/Datalust.ClefTool/Datalust.ClefTool.csproj
+++ b/src/Datalust.ClefTool/Datalust.ClefTool.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="serilog" Version="2.4.0" />
     <PackageReference Include="serilog.filters.expressions" Version="1.0.1" />
     <PackageReference Include="serilog.formatting.compact" Version="1.0.0" />
-    <PackageReference Include="serilog.formatting.compact.reader" Version="1.0.0" />
+    <PackageReference Include="serilog.formatting.compact.reader" Version="1.0.1" />
     <PackageReference Include="serilog.sinks.console" Version="2.1.0" />
     <PackageReference Include="serilog.sinks.file" Version="3.2.0" />
     <PackageReference Include="serilog.sinks.literate" Version="2.1.0" />


### PR DESCRIPTION
Required to properly deserialize/render structure values.