### PR TITLE
Add BatchPostingLimit and EventBodyLimitBytes options in SeqOutputFeature

### DIFF
--- a/src/Datalust.ClefTool/Cli/Commands/PipeCommand.cs
+++ b/src/Datalust.ClefTool/Cli/Commands/PipeCommand.cs
@@ -71,8 +71,8 @@ namespace Datalust.ClefTool.Cli.Commands
                         _seqOutputFeature.SeqUrl,
                         apiKey: _seqOutputFeature.SeqApiKey,
                         compact: true,
-                        batchPostingLimit: 100,
-                        eventBodyLimitBytes: 1024 * 1024,
+                        batchPostingLimit: _seqOutputFeature.BatchPostingLimit,
+                        eventBodyLimitBytes: _seqOutputFeature.EventBodyLimitBytes,
                         controlLevelSwitch: levelSwitch);
                 }
                 else if (_jsonFormatFeature.UseJsonFormat)

--- a/src/Datalust.ClefTool/Cli/Features/SeqOutputFeature.cs
+++ b/src/Datalust.ClefTool/Cli/Features/SeqOutputFeature.cs
@@ -16,8 +16,13 @@ namespace Datalust.ClefTool.Cli.Features
 {
     class SeqOutputFeature : CommandFeature
     {
+        public const int DefaultBatchPostingLimit = 100;
+        public const long DefaultEventBodyLimitBytes = 256 * 1000;
+
         public string SeqUrl { get; private set; }
         public string SeqApiKey { get; private set; }
+        public int BatchPostingLimit { get; private set; }
+        public long? EventBodyLimitBytes { get; private set; }
 
         public override void Enable(OptionSet options)
         {
@@ -28,6 +33,14 @@ namespace Datalust.ClefTool.Cli.Features
             options.Add("out-seq-apikey=",
                 "Specify the API key to use when writing to Seq, if required",
                 v => SeqApiKey = string.IsNullOrWhiteSpace(v) ? null : v.Trim());
+            
+            options.Add("out-seq-batchPostingLimit=",
+                "The maximum number of events to post in a single batch",
+                v => BatchPostingLimit = string.IsNullOrWhiteSpace(v) ? DefaultBatchPostingLimit : (int.TryParse(v.Trim(), out var postingLimit) ? postingLimit : DefaultBatchPostingLimit));
+
+            options.Add("out-seq-eventBodyLimitBytes=",
+                "The maximum size, in bytes, that the JSON representation of an event may take before it is dropped rather than being sent to the Seq server",
+                v => EventBodyLimitBytes = string.IsNullOrWhiteSpace(v) ? DefaultEventBodyLimitBytes : (long.TryParse(v.Trim(), out var bodyLimit) ? bodyLimit : DefaultEventBodyLimitBytes));   
         }
     }
 }

--- a/src/Datalust.ClefTool/Cli/Features/SeqOutputFeature.cs
+++ b/src/Datalust.ClefTool/Cli/Features/SeqOutputFeature.cs
@@ -34,11 +34,11 @@ namespace Datalust.ClefTool.Cli.Features
                 "Specify the API key to use when writing to Seq, if required",
                 v => SeqApiKey = string.IsNullOrWhiteSpace(v) ? null : v.Trim());
             
-            options.Add("out-seq-batchPostingLimit=",
+            options.Add("out-seq-batchpostinglimit=",
                 "The maximum number of events to post in a single batch",
                 v => BatchPostingLimit = string.IsNullOrWhiteSpace(v) ? DefaultBatchPostingLimit : (int.TryParse(v.Trim(), out var postingLimit) ? postingLimit : DefaultBatchPostingLimit));
 
-            options.Add("out-seq-eventBodyLimitBytes=",
+            options.Add("out-seq-eventbodylimitbytes=",
                 "The maximum size, in bytes, that the JSON representation of an event may take before it is dropped rather than being sent to the Seq server",
                 v => EventBodyLimitBytes = string.IsNullOrWhiteSpace(v) ? DefaultEventBodyLimitBytes : (long.TryParse(v.Trim(), out var bodyLimit) ? bodyLimit : DefaultEventBodyLimitBytes));   
         }


### PR DESCRIPTION
Currently batchPostingLimit and eventBodyLimitBytes parameters' values are hardcoded in SeqOptionFeature. These options should be configurable.