### PR TITLE
Modernization

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -1,6 +1,6 @@
 $ErrorActionPreference = 'Stop'
 
-$framework = 'net5.0'
+$framework = 'net6.0'
 
 function Clean-Output
 {
@@ -29,7 +29,9 @@ function Publish-Archives($version)
 	foreach ($rid in $rids) {
 	    $tfm = $framework
 	    
-		& dotnet publish ./src/Datalust.ClefTool/Datalust.ClefTool.csproj -c Release -f $tfm -r $rid /p:VersionPrefix=$version
+		& dotnet publish ./src/Datalust.ClefTool/Datalust.ClefTool.csproj -c Release -f $tfm -r $rid /p:VersionPrefix=$version `
+		    /p:PublishSingleFile=true /p:SelfContained=true /p:PublishReadyToRun=true
+
 		if($LASTEXITCODE -ne 0) { exit 4 }
 
 		# Make sure the archive contains a reasonable root filename

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ The `clef` command-line tool reads and processes the newline-delimited JSON stre
 
 ### What does CLEF look like?
 
-CLEF is a very simple, compact JSON event format with standardized fields for timestamps, messages, levels and so-on.
+[CLEF](https://clef-json.org) is a very simple, compact JSON event format with standardized fields for timestamps, messages, levels and so-on.
 
 ```json
-{"@t":"2017-05-09T01:23:45.67890Z","@mt":"Starting up","MachineName":"web-53a889fe"}
+{"@t":"2022-05-09T01:23:45.67890Z","@mt":"Starting up","MachineName":"web-53a889fe"}
 ```
 
 ### Reading CLEF files
@@ -15,26 +15,26 @@ CLEF is a very simple, compact JSON event format with standardized fields for ti
 The default action, given a CLEF file, will be to pretty-print it in text format to the console.
 
 ```
-> clef -i log-20170509.clef
-[2017-05-09T01:23:45.67890Z INF] Starting up
-[2017-05-09T01:23:45.96950Z INF] Checking for updates to version 123.4
+> clef -i log-20220509.clef
+[2022-05-09T01:23:45.67890Z INF] Starting up
+[2022-05-09T01:23:45.96950Z INF] Checking for updates to version 123.4
 ...
 ```
 
 The tool also accepts events on STDIN:
 
 ```
-> cat log-20170509.clef | clef
+> cat log-20220509.clef | clef
 ...
 ```
 
 ### Filtering
 
-Expressions using the [_Serilog.Filters.Expressions_](https://github.com/serilog/serilog-filters-expressions) syntax can be specified to filter the stream:
-
+Expressions using the [_Serilog.Expressions_](https://github.com/serilog/serilog-expressions) syntax can be specified to filter the stream:
+~~~~
 ```
-> clef -i log-20170509.clef --filter="Version > 100"
-[2017-05-09T01:23:45.96950Z INF] Checking for updates to version 123.4
+> clef -i log-20220509.clef --filter="Version > 100"
+[2022-05-09T01:23:45.96950Z INF] Checking for updates to version 123.4
 ```
 
 ### Formats
@@ -44,15 +44,15 @@ Output will be plain text unless another format is specified.
 Write the output in JSON format using `--format-json`:
 
 ```
-> clef -i log-20170509.clef --format-json
-{"@t":"2017-05-09T01:23:45.67890Z","@mt":"Starting up"}
+> clef -i log-20220509.clef --format-json
+{"@t":"2022-05-09T01:23:45.67890Z","@mt":"Starting up"}
 ...
 ```
 
 Control the output text format using `--format-template`:
 
 ```
-> clef -i log-20170509.clef --format-template="{Message}{NewLine}"
+> clef -i log-20220509.clef --format-template="{Message}{NewLine}"
 Starting up
 ...
 ```
@@ -64,13 +64,13 @@ Output will be written to STDOUT unless another destination is specified.
 Write output to a file with `-o`:
 
 ```
-> clef -i log-20170509.clef -o log-20170509.txt
+> clef -i log-20220509.clef -o log-20220509.txt
 ```
 
 Send the output to [Seq](https://getseq.net) by specifying a server URL and optional API key:
 
 ```
-> clef -i log-20170509.clef --out-seq="https://seq.example.com" --out-seq-apikey="1234567890"
+> clef -i log-20220509.clef --out-seq="https://seq.example.com" --out-seq-apikey="1234567890"
 ```
 
 ### Enrichment
@@ -78,6 +78,6 @@ Send the output to [Seq](https://getseq.net) by specifying a server URL and opti
 Events can be enriched with additional properties by specifying them using the `-p` switch:
 
 ```
-> clef -i log-20170509.clef -p CustomerId=C123 -p Environment=Support [...]
+> clef -i log-20220509.clef -p CustomerId=C123 -p Environment=Support [...]
 ```
 

--- a/README.md
+++ b/README.md
@@ -68,10 +68,12 @@ Write the output in JSON format using `--format-json`:
 Control the output text format using `--format-template`:
 
 ```
-> clef -i log-20220509.clef --format-template="{Message}{NewLine}"
+> clef -i log-20220509.clef --format-template="{@m}`n"
 Starting up
 ...
 ```
+
+Escaping of embedded newlines is shell-dependent; PowerShell <code>`n</code> syntax is shown.
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,22 @@ The `clef` command-line tool reads and processes the newline-delimited JSON stre
 {"@t":"2022-05-09T01:23:45.67890Z","@mt":"Starting up","MachineName":"web-53a889fe"}
 ```
 
+### Getting started
+
+[Binary releases](https://github.com/datalust/clef-tool/releases) can be downloaded directly from this project.
+
+Or, if you have `dotnet` installed, `clef` can be installed as a global tool using:
+
+```
+dotnet tool install --global Datalust.ClefTool
+```
+
+And run with:
+
+```
+dotnet clef --help
+```
+
 ### Reading CLEF files
 
 The default action, given a CLEF file, will be to pretty-print it in text format to the console.
@@ -31,7 +47,7 @@ The tool also accepts events on STDIN:
 ### Filtering
 
 Expressions using the [_Serilog.Expressions_](https://github.com/serilog/serilog-expressions) syntax can be specified to filter the stream:
-~~~~
+
 ```
 > clef -i log-20220509.clef --filter="Version > 100"
 [2022-05-09T01:23:45.96950Z INF] Checking for updates to version 123.4
@@ -80,4 +96,3 @@ Events can be enriched with additional properties by specifying them using the `
 ```
 > clef -i log-20220509.clef -p CustomerId=C123 -p Environment=Support [...]
 ```
-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
-version: 1.1.{build}
+version: 2.0.{build}
 skip_tags: true
-image: Visual Studio 2019
+image: Visual Studio 2022
 build_script:
 - ps: ./Build.ps1
 test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,11 +7,18 @@ test: off
 artifacts:
 - path: artifacts/clef-*.zip
 - path: artifacts/clef-*.tar.gz
-- path: artifacts/clef.*.nupkg
+- path: artifacts/Datalust.ClefTool.*.nupkg
 deploy:
 - provider: GitHub
   auth_token:
     secure: Bo3ypKpKFxinjR9ShkNekNvkob2iklHJU+UlYyfHtcFFIAa58SV2TkEd0xWxz633
   tag: v$(appveyor_build_version)
+  on:
+    branch: main
+- provider: NuGet
+  api_key:
+    secure: qtcwO3xYGEpN9X+BQNViwuuIJfGBEExqoctZoFFkPsnCz5/mY87S55M+gCDprrno
+  skip_symbols: true
+  artifact: /Datalust.ClefTool\..*\.nupkg/
   on:
     branch: main

--- a/src/Datalust.ClefTool/Cli/CommandLineHost.cs
+++ b/src/Datalust.ClefTool/Cli/CommandLineHost.cs
@@ -14,9 +14,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Reflection;
 using Autofac.Features.Metadata;
 
 namespace Datalust.ClefTool.Cli
@@ -30,11 +28,8 @@ namespace Datalust.ClefTool.Cli
             _availableCommands = availableCommands.ToList();
         }
         
-        public int Run(string[] args, TextWriter cout, TextWriter cerr)
+        public int Run(string[] args)
         {
-            var ea = Assembly.GetEntryAssembly();
-            var name = ea.GetName().Name;
-
             if (args.Length > 0)
             {
                 var norm = args[0].ToLowerInvariant();

--- a/src/Datalust.ClefTool/Cli/CommandMetadata.cs
+++ b/src/Datalust.ClefTool/Cli/CommandMetadata.cs
@@ -16,7 +16,7 @@ namespace Datalust.ClefTool.Cli
 {
     public class CommandMetadata : ICommandMetadata
     {
-        public string Name { get; set; }
-        public string HelpText { get; set; }
+        public string Name { get; set; } = null!;
+        public string HelpText { get; set; } = null!;
     }
 }

--- a/src/Datalust.ClefTool/Cli/Commands/HelpCommand.cs
+++ b/src/Datalust.ClefTool/Cli/Commands/HelpCommand.cs
@@ -34,7 +34,7 @@ namespace Datalust.ClefTool.Cli.Commands
         {
             // This is a little hacky; we always show the help for the (anonymous) "pipe" command.
 
-            var ea = Assembly.GetEntryAssembly();
+            var ea = Assembly.GetEntryAssembly()!;
             var name = ea.GetName().Name;
 
             var cmd = _availableCommands.SingleOrDefault(c => c.Metadata.Name == "pipe");

--- a/src/Datalust.ClefTool/Cli/Commands/PipeCommand.cs
+++ b/src/Datalust.ClefTool/Cli/Commands/PipeCommand.cs
@@ -9,7 +9,8 @@ using Serilog.Debugging;
 using Serilog.Events;
 using Serilog.Formatting.Compact;
 using Serilog.Formatting.Compact.Reader;
-using Serilog.Formatting.Display;
+using Serilog.Templates;
+using Serilog.Templates.Themes;
 
 // ReSharper disable UnusedType.Global
 
@@ -27,7 +28,7 @@ namespace Datalust.ClefTool.Cli.Commands
         readonly SeqOutputFeature _seqOutputFeature;
         readonly InvalidDataHandlingFeature _invalidDataHandlingFeature;
 
-        const string DefaultOutputTemplate = "[{Timestamp:o} {Level:u3}] {Message} {Properties}{NewLine}{Exception}";
+        static readonly string DefaultOutputTemplate = "[{@t:o} {@l:u3}] {@m:lj} {rest(true)}" + Environment.NewLine + "{@x}";
 
         public PipeCommand()
         {
@@ -91,14 +92,13 @@ namespace Datalust.ClefTool.Cli.Commands
                     var template = _templateFormatFeature.OutputTemplate ?? DefaultOutputTemplate;
                     if (_fileOutputFeature.OutputFilename != null)
                     {
-                        // This will differ slightly from the console output until `{Message:l}` becomes available
-                        configuration.AuditTo.File(
-                            new MessageTemplateTextFormatter(template, CultureInfo.InvariantCulture),
-                            _fileOutputFeature.OutputFilename);
+                        var formatter = new ExpressionTemplate(template, CultureInfo.InvariantCulture);
+                        configuration.AuditTo.File(formatter, _fileOutputFeature.OutputFilename);
                     }
                     else
                     {
-                        configuration.WriteTo.Console(outputTemplate: template);
+                        var formatter = new ExpressionTemplate(template, CultureInfo.InvariantCulture, theme: TemplateTheme.Literate);
+                        configuration.WriteTo.Console(formatter);
                     }
                 }
 

--- a/src/Datalust.ClefTool/Cli/Commands/VersionCommand.cs
+++ b/src/Datalust.ClefTool/Cli/Commands/VersionCommand.cs
@@ -22,7 +22,7 @@ namespace Datalust.ClefTool.Cli.Commands
     {
         protected override int Run()
         {
-            var version = Assembly.GetEntryAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+            var version = Assembly.GetEntryAssembly()!.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion;
             Console.WriteLine(version);
             return 0;
         }

--- a/src/Datalust.ClefTool/Cli/Features/EnrichFeature.cs
+++ b/src/Datalust.ClefTool/Cli/Features/EnrichFeature.cs
@@ -18,9 +18,9 @@ namespace Datalust.ClefTool.Cli.Features
 {
     class EnrichFeature : CommandFeature
     {
-        readonly Dictionary<string, object> _properties = new Dictionary<string, object>();
+        readonly Dictionary<string, object?> _properties = new();
 
-        public Dictionary<string, object> Properties => _properties; 
+        public Dictionary<string, object?> Properties => _properties; 
          
         public override void Enable(OptionSet options)
         {

--- a/src/Datalust.ClefTool/Cli/Features/FileInputFeature.cs
+++ b/src/Datalust.ClefTool/Cli/Features/FileInputFeature.cs
@@ -16,7 +16,7 @@ namespace Datalust.ClefTool.Cli.Features
 {
     class FileInputFeature : CommandFeature
     {
-        public string InputFilename { get; private set; }
+        public string? InputFilename { get; private set; }
 
         public override void Enable(OptionSet options)
         {

--- a/src/Datalust.ClefTool/Cli/Features/FileOutputFeature.cs
+++ b/src/Datalust.ClefTool/Cli/Features/FileOutputFeature.cs
@@ -16,7 +16,7 @@ namespace Datalust.ClefTool.Cli.Features
 {
     class FileOutputFeature : CommandFeature
     {
-        public string OutputFilename { get; private set; }
+        public string? OutputFilename { get; private set; }
 
         public override void Enable(OptionSet options)
         {

--- a/src/Datalust.ClefTool/Cli/Features/FilterFeature.cs
+++ b/src/Datalust.ClefTool/Cli/Features/FilterFeature.cs
@@ -16,7 +16,7 @@ namespace Datalust.ClefTool.Cli.Features
 {
     class FilterFeature : CommandFeature
     {
-        public string Filter { get; set; }
+        public string? Filter { get; set; }
 
         public override void Enable(OptionSet options)
         {

--- a/src/Datalust.ClefTool/Cli/Features/SeqOutputFeature.cs
+++ b/src/Datalust.ClefTool/Cli/Features/SeqOutputFeature.cs
@@ -16,8 +16,8 @@ namespace Datalust.ClefTool.Cli.Features
 {
     class SeqOutputFeature : CommandFeature
     {
-        public string SeqUrl { get; private set; }
-        public string SeqApiKey { get; private set; }
+        public string? SeqUrl { get; private set; }
+        public string? SeqApiKey { get; private set; }
         public int BatchPostingLimit { get; private set; } = 100;
         public long? EventBodyLimitBytes { get; private set; } = 256 * 1000;
 

--- a/src/Datalust.ClefTool/Cli/Features/TemplateFormatFeature.cs
+++ b/src/Datalust.ClefTool/Cli/Features/TemplateFormatFeature.cs
@@ -16,7 +16,7 @@ namespace Datalust.ClefTool.Cli.Features
 {
     class TemplateFormatFeature : CommandFeature
     {
-        public string OutputTemplate { get; private set; }
+        public string? OutputTemplate { get; private set; }
 
         public override void Enable(OptionSet options)
         {

--- a/src/Datalust.ClefTool/Cli/Options.cs
+++ b/src/Datalust.ClefTool/Cli/Options.cs
@@ -136,6 +136,8 @@ using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 
+#nullable disable
+
 #if LINQ
 using System.Linq;
 #endif

--- a/src/Datalust.ClefTool/Datalust.ClefTool.csproj
+++ b/src/Datalust.ClefTool/Datalust.ClefTool.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RuntimeIdentifiers>win-x64;linux-x64;linux-musl-x64;osx-x64</RuntimeIdentifiers>
     <GenerateAssemblyInformationalVersionAttribute>True</GenerateAssemblyInformationalVersionAttribute>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
@@ -10,16 +10,17 @@
     <Platforms>x64</Platforms>
     <AssemblyName>clef</AssemblyName>
     <ApplicationIcon>ClefTool.ico</ApplicationIcon>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="autofac" Version="6.2.0" />
+    <PackageReference Include="autofac" Version="6.3.0" />
     <PackageReference Include="serilog" Version="2.10.0" />
-    <PackageReference Include="serilog.filters.expressions" Version="2.1.0" />
+    <PackageReference Include="serilog.expressions" Version="3.3.0" />
     <PackageReference Include="serilog.formatting.compact" Version="1.1.0" />
     <PackageReference Include="serilog.formatting.compact.reader" Version="1.0.5" />
-    <PackageReference Include="serilog.sinks.console" Version="4.0.0" />
+    <PackageReference Include="serilog.sinks.console" Version="4.0.1" />
     <PackageReference Include="serilog.sinks.file" Version="5.0.0" />
-    <PackageReference Include="serilog.sinks.seq" Version="5.0.1" />
+    <PackageReference Include="serilog.sinks.seq" Version="5.1.1" />
   </ItemGroup>
 </Project>

--- a/src/Datalust.ClefTool/Datalust.ClefTool.csproj
+++ b/src/Datalust.ClefTool/Datalust.ClefTool.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <RuntimeIdentifiers>win-x64;linux-x64;linux-musl-x64;osx-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;linux-x64;linux-musl-x64;osx-x64;osx-arm64</RuntimeIdentifiers>
     <GenerateAssemblyInformationalVersionAttribute>True</GenerateAssemblyInformationalVersionAttribute>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <TreatSpecificWarningsAsErrors />
@@ -11,6 +11,9 @@
     <AssemblyName>clef</AssemblyName>
     <ApplicationIcon>ClefTool.ico</ApplicationIcon>
     <Nullable>enable</Nullable>
+    <PackageId>Datalust.ClefTool</PackageId>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>clef</ToolCommandName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Datalust.ClefTool/Program.cs
+++ b/src/Datalust.ClefTool/Program.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Autofac;
 using Datalust.ClefTool.Cli;
 
@@ -15,11 +14,9 @@ namespace Datalust.ClefTool
                 .As<Command>()
                 .WithMetadataFrom<CommandAttribute>();
 
-            using (var container = builder.Build())
-            {
-                var clh = container.Resolve<CommandLineHost>();
-                return clh.Run(args, Console.Out, Console.Error);
-            }
+            using var container = builder.Build();
+            var clh = container.Resolve<CommandLineHost>();
+            return clh.Run(args);
         }
     }
 }

--- a/src/Datalust.ClefTool/Program.cs
+++ b/src/Datalust.ClefTool/Program.cs
@@ -1,16 +1,16 @@
-﻿using System.Reflection;
-using Autofac;
+﻿using Autofac;
 using Datalust.ClefTool.Cli;
+using Datalust.ClefTool.Cli.Commands;
 
 namespace Datalust.ClefTool
 {
-    class Program
+    static class Program
     {
         public static int Main(string[] args)
         {
             var builder = new ContainerBuilder();
             builder.RegisterType<CommandLineHost>();
-            builder.RegisterAssemblyTypes(typeof(Program).GetTypeInfo().Assembly)
+            builder.RegisterTypes(typeof(PipeCommand), typeof(HelpCommand), typeof(VersionCommand))
                 .As<Command>()
                 .WithMetadataFrom<CommandAttribute>();
 

--- a/test/Datalust.ClefTool.Tests/Datalust.ClefTool.Tests.csproj
+++ b/test/Datalust.ClefTool.Tests/Datalust.ClefTool.Tests.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
 * Update version to 2.0.0 (breaking changes)
 * Switch to _Serilog.Expressions_ for filtering and formatting; this has the advantage of using CLEF property names natively, e.g. `@m like 'TEST%'` rather than `@Message like 'TEST%`, adding `ci` modifier support, `#if`/`#each` conditional blocks, and opening up more language extension possibilities
 * Publish as a .NET 6.0 single file app
 * Add support for `osx-arm64`
 * Publish as a .NET tool (`dotnet tool install --global Datalust.ClefTool`, and `dotnet clef ...`)
 * Update README

Fixes #28, fixes #36