### PR TITLE
Add newline() as a built-in function in templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,10 @@ Write the output in JSON format using `--format-json`:
 Control the output text format using `--format-template`:
 
 ```
-> clef -i log-20220509.clef --format-template="{@m}`n"
+> clef -i log-20220509.clef --format-template="{@m}{NewLine()}"
 Starting up
 ...
 ```
-
-Escaping of embedded newlines is shell-dependent; PowerShell <code>`n</code> syntax is shown.
 
 ### Outputs
 
@@ -98,3 +96,14 @@ Events can be enriched with additional properties by specifying them using the `
 ```
 > clef -i log-20220509.clef -p CustomerId=C123 -p Environment=Support [...]
 ```
+
+### Filter and template syntax
+
+The syntax supported in the `--filter` and `--format-template` arguments is documented in the
+[_Serilog.Expressions_ language reference](https://github.com/serilog/serilog-expressions#language-reference).
+
+The following functions are added:
+
+| Function    | Description                                                                             |
+|:------------|:----------------------------------------------------------------------------------------|
+| `NewLine()` | Returns a platform-dependent newline character (supported in `--format-template` only). |

--- a/src/Datalust.ClefTool/Cli/Commands/PipeCommand.cs
+++ b/src/Datalust.ClefTool/Cli/Commands/PipeCommand.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.IO;
 using Datalust.ClefTool.Cli.Features;
 using Datalust.ClefTool.Pipe;
+using Datalust.ClefTool.Syntax;
 using Serilog;
 using Serilog.Core;
 using Serilog.Debugging;
@@ -92,12 +93,12 @@ namespace Datalust.ClefTool.Cli.Commands
                     var template = _templateFormatFeature.OutputTemplate ?? DefaultOutputTemplate;
                     if (_fileOutputFeature.OutputFilename != null)
                     {
-                        var formatter = new ExpressionTemplate(template, CultureInfo.InvariantCulture);
+                        var formatter = new ExpressionTemplate(template, CultureInfo.InvariantCulture, new ClefToolNameResolver());
                         configuration.AuditTo.File(formatter, _fileOutputFeature.OutputFilename);
                     }
                     else
                     {
-                        var formatter = new ExpressionTemplate(template, CultureInfo.InvariantCulture, theme: TemplateTheme.Literate);
+                        var formatter = new ExpressionTemplate(template, CultureInfo.InvariantCulture, new ClefToolNameResolver(), TemplateTheme.Literate);
                         configuration.WriteTo.Console(formatter);
                     }
                 }

--- a/src/Datalust.ClefTool/Syntax/ClefToolNameResolver.cs
+++ b/src/Datalust.ClefTool/Syntax/ClefToolNameResolver.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using Serilog.Events;
+using Serilog.Expressions;
+
+namespace Datalust.ClefTool.Syntax;
+
+public class ClefToolNameResolver : NameResolver
+{
+    public static LogEventPropertyValue? NewLine()
+    {
+        return new ScalarValue(Environment.NewLine);
+    }
+
+    public override bool TryResolveFunctionName(string name, [NotNullWhen(true)] out MethodInfo? implementation)
+    {
+        if (nameof(NewLine).Equals(name, StringComparison.OrdinalIgnoreCase))
+        {
+            implementation = typeof(ClefToolNameResolver).GetMethod(nameof(NewLine), BindingFlags.Public | BindingFlags.Static)!;
+            return true;
+        }
+
+        return base.TryResolveFunctionName(name, out implementation);
+    }
+}

--- a/test/Datalust.ClefTool.Tests/ClefToolNameResolverTests.cs
+++ b/test/Datalust.ClefTool.Tests/ClefToolNameResolverTests.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using Datalust.ClefTool.Syntax;
+using Serilog.Events;
+using Serilog.Templates;
+using Xunit;
+
+namespace Datalust.ClefTool.Tests;
+
+public class ClefToolNameResolverTests
+{
+    [Fact]
+    public void NewlineFunctionEvaluatesToNewlineInTemplates()
+    {
+        var template = new ExpressionTemplate("a{newline()}b", nameResolver: new ClefToolNameResolver());
+        var output = new StringWriter();
+        var evt = new LogEvent(DateTimeOffset.Now, LogEventLevel.Debug, null, MessageTemplate.Empty,
+            Enumerable.Empty<LogEventProperty>());
+        template.Format(evt, output);
+        var result = output.ToString();
+        Assert.Equal($"a{Environment.NewLine}b", result);
+    }
+}
+


### PR DESCRIPTION
Literal newlines are hard to pass through CLI arguments.

Looks like:

```
... --format-template="{@m}{newline()}"
```
