### PR TITLE
2.0.* Maintenance Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ dotnet tool install --global Datalust.ClefTool
 And run with:
 
 ```
-dotnet clef --help
+clef --help
 ```
 
 ### Reading CLEF files

--- a/src/Datalust.ClefTool/Datalust.ClefTool.csproj
+++ b/src/Datalust.ClefTool/Datalust.ClefTool.csproj
@@ -14,6 +14,7 @@
     <PackageId>Datalust.ClefTool</PackageId>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>clef</ToolCommandName>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
 * #42 - allow major version roll forward, so that the `dotnet tool` package runs with any 6.0+ .NET version installed (@nblumhardt)